### PR TITLE
main.go: accept a URL instead of addr

### DIFF
--- a/README
+++ b/README
@@ -27,9 +27,9 @@ To add a record named name to the log:
 
 To serve the authenticated log data:
 
-    tlogdb [-a addr] [-f file] serve
+    tlogdb [-u url] [-f file] serve
 
-The default server address is localhost:6655.
+The default server url is http://localhost:6655.
 
 
 Client Operations
@@ -48,9 +48,9 @@ of the tlogdb's server commands newlog or publickey, described above.
 
 To look up a record in the log:
 
-    tlogdb [-a addr] [-c file] lookup name
+    tlogdb [-u url] [-c file] lookup name
 
-The default server address is again localhost:6655.
+The default server url is again http://localhost:6655.
 
 
 Example


### PR DESCRIPTION
I wanted to try this tool out against the https://sum.golang.org
endpoint but http:// was hard coded. Change the `-a` flag to `-u` and
accept a schema.

Usage:

tlogdb newcache sum.golang.org+033de0ae+Ac4zctda0e5eza+HJyk9SxEdh+s3Ux18htTTAD8OuAn8
tlogdb -u https://sum.golang.org:443 lookup go.etcd.io/etcd@v0.4.0